### PR TITLE
Standardize README: badges, Conda install, License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cellosaurus
 
-[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/recipes/r-cellosaurus/README.html) ![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
+[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/r-cellosaurus/README.html) ![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
 
 [Cellosaurus][] identifier mapping toolkit.
 
@@ -35,10 +35,9 @@ R
 ```
 
 [bioconda]: https://bioconda.github.io/
-[conda]: https://conda.io/
+[conda]: https://docs.conda.io/
 [cellosaurus]: https://www.cellosaurus.org/
 [r]: https://www.r-project.org/
-
 
 ## License
 


### PR DESCRIPTION
- Normalize bioconda badge URL (http → https)
- Fix [conda] link ref (conda.io → docs.conda.io)
- Remove extra blank line before License section